### PR TITLE
Commercial vnet gw pip

### DIFF
--- a/zero trust architecture blueprint/zero-trust-architecture-v2/README.md
+++ b/zero trust architecture blueprint/zero-trust-architecture-v2/README.md
@@ -45,11 +45,11 @@ More on Azure Blueprint can be found [here](https://docs.microsoft.com/en-us/azu
 
 5. Run the following command to import artifacts as blueprint and save it within the specified subscription or management group.
     ```powershell
-    Import-AzBlueprintWithArtifact -Name "YourBlueprintName" -SubscriptionId "00000000-1111-0000-1111-000000000000" -InputPath "$HOME/clouddrive/ato-toolkit/automation/zero-trust-architecture-v2/blueprint"
+    Import-AzBlueprintWithArtifact -Name "YourBlueprintName" -SubscriptionId "00000000-1111-0000-1111-000000000000" -InputPath "$HOME/clouddrive/ato-toolkit/zero trust architecture blueprint/zero-trust-architecture-v2/blueprint"
     ```
 
     > [!IMPORTANT]
-    > Use -InputPath "$HOME/clouddrive/ato-toolkit/automation/zero-trust-architecture-v2/blueprint_gov" for AzureUSGovernment environment.
+    > Use -InputPath "$HOME/clouddrive/ato-toolkit/zero trust architecture blueprint/zero-trust-architecture-v2/blueprint_gov" for AzureUSGovernment environment.
 
     > [!NOTE]
     > The input path must point to the folder where blueprint.json file is placed.

--- a/zero trust architecture blueprint/zero-trust-architecture-v2/blueprint/artifacts/hub-shared-network-gateway.json
+++ b/zero trust architecture blueprint/zero-trust-architecture-v2/blueprint/artifacts/hub-shared-network-gateway.json
@@ -61,13 +61,13 @@
           "location": "[variables('location')]",
           "condition": "[parameters('deployHub')]",
           "sku": {
-            "name": "Standard"
+            "name": "Basic"
           },
           "tags": {
             "component": "hub-shared-network-gateway"
           },
           "properties": {
-            "publicIPAllocationMethod": "Static",
+            "publicIPAllocationMethod": "Dynamic",
             "publicIPAddressVersion": "IPv4"
           }
         },


### PR DESCRIPTION
Commercial ZTA blueprint assignment fails with the following errors in its current state:
"Virtual network gateway /subscriptions/<redacted>/resourceGroups/zta-hub-shared-rg/providers/Microsoft.Network/virtualNetworkGateways/zta-hub-shared-vpn-gw cannot reference standard sku public IP <redacted>."

The VPN gateway deployed in the commercial ZTA blueprint does not support static public IP addresses according to [official docs](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-vpn-faq#can-i-request-a-static-public-ip-address-for-my-vpn-gateway)

VPN Gateway PIP has been modified to use the Basic SKU with Dynamic allocation, making it consistent with the Azure US Government ZTA Blueprint.

The PowerShell commands in the blueprint README have also been updated to reflect the repo structure.