### PR TITLE
Adding support for a GEN2 RHEL8.1 VM

### DIFF
--- a/stig/linux/mainTemplate.json
+++ b/stig/linux/mainTemplate.json
@@ -59,6 +59,7 @@
                 "RHEL84",
                 "RHEL83",
                 "RHEL82",
+                "RHEL81GEN2",
                 "RHEL81",
                 "RHEL80",
                 "RHEL79",
@@ -246,7 +247,7 @@
                 "id": "[parameters('applicationSecurityGroupResourceId')]"
             }
         ],
-        "rhel8Versions": "[createArray('RHEL80', 'RHEL81', 'RHEL82', 'RHEL83', 'RHEL84')]",
+        "rhel8Versions": "[createArray('RHEL80', 'RHEL81', 'RHEL81GEN2', 'RHEL82', 'RHEL83', 'RHEL84')]",
         "linuxBashUri": "[concat(parameters('_artifactsLocation'), variables('images')[parameters('osVersion')].stigFileName, variables('artifactsLocationSasToken'))]",
         "rhel8FileUri": "[concat(parameters('_artifactsLocation'), 'config/', 'rhel8STIG-ansible.zip', variables('artifactsLocationSasToken'))]",
         "mofDscFileUri": "[concat(parameters('_artifactsLocation'), 'config/', parameters('osVersion'), '.mof', variables('artifactsLocationSasToken'))]",
@@ -332,6 +333,15 @@
                     "publisher": "RedHat",
                     "offer": "RHEL",
                     "sku": "8.2",
+                    "version": "latest"
+                },
+                "stigFileName": "rhel8STIG.sh"
+            },
+            "RHEL81GEN2": {
+                "reference": {
+                    "publisher": "RedHat",
+                    "offer": "RHEL",
+                    "sku": "81gen2",
                     "version": "latest"
                 },
                 "stigFileName": "rhel8STIG.sh"

--- a/stig/tools/scale-deployment.ps1
+++ b/stig/tools/scale-deployment.ps1
@@ -183,6 +183,7 @@ Param
         "RHEL84",
         "RHEL83",
         "RHEL82",
+        "RHEL81GEN2",
         "RHEL81",
         "RHEL80",
         "RHEL79",


### PR DESCRIPTION
We needed to be able to create a generation 2 style VM which required specific skus to be able to be specified.  This PR adds that support after identifying a desired sku using `az vm image list --publisher RedHat --sku gen2 --output table --all` and finding :

|Offer                |  Publisher |   Sku                | Urn                                                                        |  Version
|---------------- | ----------- |  --------------- |  ---------------------------------------------------- |  -------------- |
| RHEL               | RedHat     |  81gen2           | RedHat:RHEL:81gen2:8.1.2022031404                  | 8.1.2022031404 |