### PR TITLE
Update scale-deployment.ps1

### DIFF
--- a/stig/tools/scale-deployment.ps1
+++ b/stig/tools/scale-deployment.ps1
@@ -406,7 +406,7 @@ if ($PSCmdlet.ParameterSetName -eq 'Default')
 
     # creating VM names based on user input
     $vmNames = [System.Collections.Specialized.OrderedDictionary]::new()
-    for ($i = $VmNameSuffixStartingNumber; $i -le $Count; $i++)
+    for ($i = $VmNameSuffixStartingNumber; $i -le ($VmNameSuffixStartingNumber + $Count); $i++)
     {
         $assembledVmName = '{0}{1}{2}{3}' -f $VmNamePrefix, $VmName, $VmNameSuffixDelimiter, $i
         if ($AvailabilityOptions -eq 'availabilitySet')


### PR DESCRIPTION
This change will allow users to add VMs to an existing deployment.  The user would be able to call the script again but set starting suffix as the next VM that they want and add any number of additional VMs. Current logic doesn't allow for this use case.

For e.g. I have vm0, vm1, and vm2 deployed but want to add vm3 and vm4 therefore startingsuffix = 3 and count = 1.  This now works.